### PR TITLE
Replace rootVC when LoginVC is transistioning to main.  AlarmSchedule…

### DIFF
--- a/Ambiance/AlarmScheduler.swift
+++ b/Ambiance/AlarmScheduler.swift
@@ -19,9 +19,8 @@ class AlarmScheduler: NSObject {
     let calendar = Calendar(identifier: .gregorian)
     var alarmObject: AlarmObject!
     
-    init(vc: UIViewController) {
+    override init() {
         super.init()
-        self.mainVc = vc
         // FIXME - sound file location needs to be set from Parse        
         self.alarmObject = AlarmObject(itemToPlay: URL(string:
             "https://dream-team-bucket.s3-us-west-1.amazonaws.com/music/morning-forest.mp3")!)
@@ -63,11 +62,30 @@ class AlarmScheduler: NSObject {
     
     // Put up AlarmOn VC with modal transition
     func showAlarmOn(_ alarm: AlarmObject) {
-        let alarmOnStoryboard = UIStoryboard(name: "AlarmOn", bundle: nil)
-        let alarmOnVcNavigation = alarmOnStoryboard.instantiateViewController(withIdentifier: "AlarmOnNavigationController") as! UINavigationController
-        let alarmOnVc = alarmOnVcNavigation.viewControllers[0] as! AlarmOnViewController
-        alarmOnVc.alarmObject = alarm
-        self.mainVc?.present(alarmOnVcNavigation, animated: true, completion: nil)
+        let mainVc = findMainVc()
+        if let mainVc = mainVc {
+            let alarmOnStoryboard = UIStoryboard(name: "AlarmOn", bundle: nil)
+            let alarmOnVcNavigation = alarmOnStoryboard.instantiateViewController(withIdentifier: "AlarmOnNavigationController") as! UINavigationController
+            let alarmOnVc = alarmOnVcNavigation.viewControllers[0] as! AlarmOnViewController
+            alarmOnVc.alarmObject = alarm
+            mainVc.present(alarmOnVcNavigation, animated: true, completion: nil)
+        }
+    }
+    
+    func findMainVc() -> MainViewController? {
+        let appDelegate  = UIApplication.shared.delegate
+        let viewController = appDelegate?.window??.rootViewController
+        if viewController is MainViewController {
+            return viewController as? MainViewController
+        } else {
+            let childVcs = viewController?.childViewControllers
+            for childVc in childVcs! {
+                if childVc is MainViewController {
+                    return childVc as? MainViewController
+                }
+            }
+        }
+        return nil
     }
     
     // Inspect the current user's AlarmSchedule, search for the next alarm that is scheduled,

--- a/Ambiance/AlarmScheduler.swift
+++ b/Ambiance/AlarmScheduler.swift
@@ -60,33 +60,12 @@ class AlarmScheduler: NSObject {
         }
     }
     
-    // Put up AlarmOn VC with modal transition
+    // Broadcast change
     func showAlarmOn(_ alarm: AlarmObject) {
-        let mainVc = findMainVc()
-        if let mainVc = mainVc {
-            let alarmOnStoryboard = UIStoryboard(name: "AlarmOn", bundle: nil)
-            let alarmOnVcNavigation = alarmOnStoryboard.instantiateViewController(withIdentifier: "AlarmOnNavigationController") as! UINavigationController
-            let alarmOnVc = alarmOnVcNavigation.viewControllers[0] as! AlarmOnViewController
-            alarmOnVc.alarmObject = alarm
-            mainVc.present(alarmOnVcNavigation, animated: true, completion: nil)
-        }
+        let alarmDict:[String: AlarmObject] = ["alarm": alarm]
+        NotificationCenter.default.post(name: .alarmStartedNotification, object: nil, userInfo: alarmDict)
     }
     
-    func findMainVc() -> MainViewController? {
-        let appDelegate  = UIApplication.shared.delegate
-        let viewController = appDelegate?.window??.rootViewController
-        if viewController is MainViewController {
-            return viewController as? MainViewController
-        } else {
-            let childVcs = viewController?.childViewControllers
-            for childVc in childVcs! {
-                if childVc is MainViewController {
-                    return childVc as? MainViewController
-                }
-            }
-        }
-        return nil
-    }
     
     // Inspect the current user's AlarmSchedule, search for the next alarm that is scheduled,
     // and return it as an (alarm start Date, DayAlarm) pair, or nil if not found.
@@ -152,4 +131,9 @@ class AlarmScheduler: NSObject {
         return weekDay
     }
     
+}
+
+
+extension Notification.Name {
+    static let alarmStartedNotification = Notification.Name("alarmStarted")
 }

--- a/Ambiance/LoginViewController.swift
+++ b/Ambiance/LoginViewController.swift
@@ -58,11 +58,7 @@ class LoginViewController: UIViewController {
     func navigateToHomeScreen() {
         let mainStoryboard = UIStoryboard(name: "Infrastructure", bundle: nil)
         let mainVc = mainStoryboard.instantiateViewController(withIdentifier: "main") as! MainViewController
-        //self.present(mainVc, animated: true, completion: nil)
-        //self.show(mainVc, sender: self)
-
-        let appDelegate  = UIApplication.shared.delegate
-        appDelegate?.window??.rootViewController = mainVc
+        self.present(mainVc, animated: true, completion: nil)
     }
 }
 

--- a/Ambiance/LoginViewController.swift
+++ b/Ambiance/LoginViewController.swift
@@ -58,7 +58,11 @@ class LoginViewController: UIViewController {
     func navigateToHomeScreen() {
         let mainStoryboard = UIStoryboard(name: "Infrastructure", bundle: nil)
         let mainVc = mainStoryboard.instantiateViewController(withIdentifier: "main") as! MainViewController
-        self.present(mainVc, animated: true, completion: nil)
+        //self.present(mainVc, animated: true, completion: nil)
+        //self.show(mainVc, sender: self)
+
+        let appDelegate  = UIApplication.shared.delegate
+        appDelegate?.window??.rootViewController = mainVc
     }
 }
 

--- a/Ambiance/MainViewController.swift
+++ b/Ambiance/MainViewController.swift
@@ -33,7 +33,7 @@ class MainViewController: UIViewController, UITabBarDelegate {
         print("\(user.profileImageUrl!)")
         tabbarView.delegate = self
         
-        self.alarmScheduler = AlarmScheduler(vc: self)
+        self.alarmScheduler = AlarmScheduler()
         let alarmScheduledDate = self.alarmScheduler.scheduleNextAlarm()
         print("next alarm scheduled at \(alarmScheduledDate)")
     }

--- a/Ambiance/MainViewController.swift
+++ b/Ambiance/MainViewController.swift
@@ -36,6 +36,9 @@ class MainViewController: UIViewController, UITabBarDelegate {
         self.alarmScheduler = AlarmScheduler()
         let alarmScheduledDate = self.alarmScheduler.scheduleNextAlarm()
         print("next alarm scheduled at \(alarmScheduledDate)")
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(self.showAlarm(_:)), name: .alarmStartedNotification, object: nil)
+
     }
 
     override func didReceiveMemoryWarning() {
@@ -74,6 +77,16 @@ class MainViewController: UIViewController, UITabBarDelegate {
         show(screen: accountVc)
     }
     
+    @objc private func showAlarm(_ notification: NSNotification) {
+        if let alarm = notification.userInfo?["alarm"] as? AlarmObject {
+            let alarmOnStoryboard = UIStoryboard(name: "AlarmOn", bundle: nil)
+            let alarmOnVcNavigation = alarmOnStoryboard.instantiateViewController(withIdentifier: "AlarmOnNavigationController") as! UINavigationController
+            let alarmOnVc = alarmOnVcNavigation.viewControllers[0] as! AlarmOnViewController
+            alarmOnVc.alarmObject = alarm
+            self.present(alarmOnVcNavigation, animated: true, completion: nil) // Modal presentation        
+        }
+    }
+    
     
     private func show(screen: UIViewController) {
         if nil != activeScreen {
@@ -90,3 +103,5 @@ class MainViewController: UIViewController, UITabBarDelegate {
     }
 
 }
+
+


### PR DESCRIPTION
…r queries root VC.

@matthew-carroll , I'm replacing root VC to be MainViewController, as I saw that LoginViewController.childViewControllers were always empty.  